### PR TITLE
fix: Improve write_chatlog performance by reusing CosmosClient instance

### DIFF
--- a/5.internal-document-search/src/backend/approaches/chatlogging.py
+++ b/5.internal-document-search/src/backend/approaches/chatlogging.py
@@ -15,6 +15,10 @@ endpoint = os.environ.get("AZURE_COSMOSDB_ENDPOINT")
 key = os.environ.get("COSMOSDB_KEY")
 database_name = os.environ.get("AZURE_COSMOSDB_DATABASE")
 container_name = os.environ.get("AZURE_COSMOSDB_CONTAINER")
+# CosmosDB Initialization
+credential = DefaultAzureCredential()
+database = CosmosClient(endpoint, credential).get_database_client(database_name)
+container = database.get_container_client(container_name)
 
 logger = logging.getLogger(__name__)
 logger.addHandler(AzureLogHandler(connection_string=os.environ.get("APPLICATIONINSIGHTS_CONNECTION_STRING")))
@@ -52,10 +56,6 @@ def write_chatlog(approach: ApproachType, user_name: str, total_tokens: int, inp
 
     if query != "":
         properties["query"] = query
-
-    credential = DefaultAzureCredential()
-    database = CosmosClient(endpoint, credential).get_database_client(database_name)
-    container = database.get_container_client(container_name)
     container.create_item(body=properties, enable_automatic_id_generation=True)
     
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Improve the performance of the write_chatlog function in Flask by reusing the CosmosClient instance.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
1. `azd login` を実行する。
2. `src` フォルダに移動する。
3. `./start.ps1` もしくは `./start.sh` を実行します。
```

## What to Check
Verify that the following are valid

* The write_chatlog function no longer generates a new CosmosClient on each call.
* The write_chatlog function successfully creates items in the CosmosDB container.


## Other Information
<!-- Add any other helpful information that may be needed here. -->