### PR TITLE
Linux 版のインデックス作成スクリプトの修正

### DIFF
--- a/5.internal-document-search/scripts/prepdocs.sh
+++ b/5.internal-document-search/scripts/prepdocs.sh
@@ -11,7 +11,7 @@ done <<EOF
 $(azd env get-values)
 EOF
 
-roleId = (az cosmosdb sql role definition create --account-name "$AZURE_COSMOSDB_ACCOUNT" --resource-group "$AZURE_COSMOSDB_RESOURCE_GROUP" --body ./scripts/cosmosreadwriterole.json --output tsv --query id)
+roleId=$(az cosmosdb sql role definition create --account-name "$AZURE_COSMOSDB_ACCOUNT" --resource-group "$AZURE_COSMOSDB_RESOURCE_GROUP" --body ./scripts/cosmosreadwriterole.json --output tsv --query id)
 az cosmosdb sql role assignment create --account-name "$AZURE_COSMOSDB_ACCOUNT" --resource-group "$AZURE_COSMOSDB_RESOURCE_GROUP" --scope / --principal-id "$BACKEND_IDENTITY_PRINCIPAL_ID" --role-definition-id $roleId
 az cosmosdb sql role assignment create --account-name "$AZURE_COSMOSDB_ACCOUNT" --resource-group "$AZURE_COSMOSDB_RESOURCE_GROUP" --scope / --principal-id "$AZURE_PRINCIPAL_ID" --role-definition-id $roleId
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
Linux 版のインデックス生成のスクリプト .prepdocs.sh にバグがあったので修正しました

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test

Linux 環境（VSCode Dev Container など）で `azd up` を実行します

## What to Check

prepdoc.sh 実行時に `az cosmosdb sql role assignment create ` 実行時にエラーがならない（修正前は変数 roleId が空になっているためエラー）

## Other Information

とりあえず初回実行時のみの修正です。
インデックス修正など２回目以降 prepdocs.sh を実行すると、同名のロールが存在する状態でロールを新規作成に行くのでエラーになります。
最終的にはロールの存在チェックなどを組み込むべきかと思います。