### PR TITLE
環境変数にApplication Insightsの接続文字列を追加

### DIFF
--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -652,3 +652,4 @@ output AZURE_COSMOSDB_RESOURCE_GROUP string = resourceGroup.name
 
 output BACKEND_IDENTITY_PRINCIPAL_ID string = backend.outputs.identityPrincipalId
 output BACKEND_URI string = backend.outputs.uri
+output APPLICATIONINSIGHTS_CONNECTION_STRING string = useApplicationInsights ? monitoring.outputs.applicationInsightsConnectionString : ''


### PR DESCRIPTION
## タイトル
デバッグ実行する際にApplication Insightsを正常に動作させるためのmain.bicepの変更

##  変更内容
azd upして環境を構築した後、デバッグ実行しようとした際、Application Insightsの接続文字列を定義する環境変数APPLICATIONINSIGHTS_CONNECTION_STRINGが未定義で、デバッグ実行に失敗しました。

よって、main.bicepを変更し、.envファイルにAPPLICATIONINSIGHTS_CONNECTION_STRINGが追加されるように変更しました。