### PR TITLE
3.goal-achievement-adviser の requirements.txt で numpy バージョンを指定

### DIFF
--- a/3.goal-achievement-adviser/app/backend/requirements.txt
+++ b/3.goal-achievement-adviser/app/backend/requirements.txt
@@ -11,3 +11,4 @@ flask-session>=0.3.2,<0.5
 requests>=2,<3
 msal>=1.7,<2
 tiktoken==0.4.0
+numpy==1.26.4


### PR DESCRIPTION
# 変更点
- 3.goal-achievement-adviser/app/backend/requirements.txt で numpy==1.26.4 を追加

# 変更理由
- 仮想環境内にて、以下の numpy 由来のエラーを解消するため (図はスクリーンショット参照)

>Exception has occurred: ValueError
numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject
  File "/home/yu/jp-azureopenai-samples/3.goal-achievement-adviser/app/backend/app.py", line 8, in <module>
    import openai
ValueError: numpy.dtype size changed, may indicate binary incompatibility. Expected 96 from C header, got 88 from PyObject

# スクリーンショット
![image](https://github.com/user-attachments/assets/fe53a5ee-dbd0-4a5d-8a7b-ec8e43a9badb)

# 参考ドキュメント
The solution is to pin down the numpy version to any before the 2.0.0. Today it could be (this is the most recent numpy 1 release):
```
numpy==1.26.4
```
https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from