### PR TITLE
what-if.yml のトリガー条件の変更

### DIFF
--- a/.github/workflows/5.what-if.yml
+++ b/.github/workflows/5.what-if.yml
@@ -1,6 +1,6 @@
 name: bicep what-if
 
-on: push
+on: workflow_dispatch
 
 jobs:
   deploy:


### PR DESCRIPTION
# 変更点
- what-if.yml のトリガー条件を `push` から `workflow_dispatch` に変更

# 変更理由
- トリガー条件が `push` だと PR 作成時の workflow にて、what-if.yml が毎回実行されてしまうため
- 毎回実行するのではなく、必要な時に実行できればよいため

# スクリーンショット
- `workflow_dispatch` に変更することで、PR 作成時ではなく手動で必要なタイミングでワークフローが実行可能になったことを確認
![image](https://github.com/user-attachments/assets/c1dc669e-64c2-40f3-928a-4c5dcc4c4d63)