### PR TITLE
GPT モデルのアップデート

### DIFF
--- a/5.internal-document-search/README.md
+++ b/5.internal-document-search/README.md
@@ -49,7 +49,7 @@
 | サービス名 | SKU | Note |
 | --- | --- | --- |
 |Azure App Service|S1||
-|Azure OpenAI Service|S0|gpt-3.5-turbo gpt-3.5-turbo-16k gpt-4 gpt-4-32k|
+|Azure OpenAI Service|S0|gpt-3.5-turbo gpt-4 gpt-4o|
 |Azure AI Search|S1||
 |Azure Cosmos DB|プロビジョニング済みスループット||
 |Azure Form Recognizer|S0||

--- a/5.internal-document-search/deploy_private_endpoint_ennabled.md
+++ b/5.internal-document-search/deploy_private_endpoint_ennabled.md
@@ -41,7 +41,7 @@ IaCとして追加・更新したファイルは以下の通りです。
 |Private Endpoint||App Service, Cognitive Service, Azure OpenAI Service, Form Recognizer, Storage Account用の5つ|
 |NNetwork Interface||Private Endpoint用の5つ|
 |Azure App Service|S1||
-|Azure OpenAI Service|S0|gpt-3.5-turbo gpt-3.5-turbo-16k|
+|Azure OpenAI Service|S0|gpt-3.5-turbo|
 |Azure AI Search|S1||
 |Azure Cosmos DB|プロビジョニング済みスループット||
 |Azure Form Recognizer|S0||

--- a/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
+++ b/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
@@ -12,29 +12,15 @@ param sku object = {
 
 param useOpenAiGpt4 bool = true
 param openAiGpt35TurboDeploymentName string = ''
-param openAiGpt35Turbo16kDeploymentName string = ''
 param openAiGpt4DeploymentName string = ''
-param openAiGpt432kDeploymentName string = ''
+param openAiGpt4oDeploymentName string = ''
 
 param openAiGpt35TurboDeployObj object = {
   name: openAiGpt35TurboDeploymentName
   model: {
     format: 'OpenAI'
     name: 'gpt-35-turbo'
-    version: '0613'
-  }
-  sku: {
-    name: 'Standard'
-    capacity: 120
-  }
-}
-
-param openAiGpt35Turbo16kDeployObj object = {
-  name: openAiGpt35Turbo16kDeploymentName
-  model: {
-    format: 'OpenAI'
-    name: 'gpt-35-turbo-16k'
-    version: '0613'
+    version: '0125'
   }
   sku: {
     name: 'Standard'
@@ -47,7 +33,7 @@ param openAiGpt4DeployObj object = {
   model: {
     format: 'OpenAI'
     name: 'gpt-4'
-    version: '0613'
+    version: 'turbo-2024-04-09'
   }
   sku: {
     name: 'Standard'
@@ -55,12 +41,12 @@ param openAiGpt4DeployObj object = {
   }
 }
 
-param openAiGpt432kDeployObj object = {
-  name: openAiGpt432kDeploymentName
+param openAiGpt4oDeployObj object = {
+  name: openAiGpt4oDeploymentName
   model: {
     format: 'OpenAI'
-    name: 'gpt-4-32k'
-    version: '0613'
+    name: 'gpt-4o'
+    version: '2024-11-20'
   }
   sku: {
     name: 'Standard'
@@ -70,12 +56,10 @@ param openAiGpt432kDeployObj object = {
 
 param deployments array = useOpenAiGpt4? [
   openAiGpt35TurboDeployObj
-  openAiGpt35Turbo16kDeployObj
   openAiGpt4DeployObj
-  openAiGpt432kDeployObj
+  openAiGpt4oDeployObj
 ]: [
   openAiGpt35TurboDeployObj
-  openAiGpt35Turbo16kDeployObj
 ]
 
 resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {

--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -57,9 +57,8 @@ param useOpenAiGpt4 bool = contains(AzureOpenAIServiceRegion, 'GPT-4')
 
 param openAiSkuName string = 'S0'
 param openAiGpt35TurboDeploymentName string = 'gpt-35-turbo-deploy'
-param openAiGpt35Turbo16kDeploymentName string = 'gpt-35-turbo-16k-deploy'
 param openAiGpt4DeploymentName string = 'gpt-4-deploy'
-param openAiGpt432kDeploymentName string = 'gpt-4-32k-deploy'
+param openAiGpt4oDeploymentName string = 'gpt-4o-deploy'
 param openAiApiVersion string = '2023-05-15'
 
 param formRecognizerServiceName string = ''
@@ -209,9 +208,8 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_SEARCH_INDEX: searchIndexName
       AZURE_SEARCH_SERVICE: searchService.outputs.name
       AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT: openAiGpt35TurboDeploymentName
-      AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT: openAiGpt35Turbo16kDeploymentName
       AZURE_OPENAI_GPT_4_DEPLOYMENT: openAiGpt4DeploymentName
-      AZURE_OPENAI_GPT_4_32K_DEPLOYMENT: openAiGpt432kDeploymentName
+      AZURE_OPENAI_GPT_4O_DEPLOYMENT: openAiGpt4oDeploymentName
       AZURE_OPENAI_API_VERSION: '2023-05-15'
       AZURE_COSMOSDB_CONTAINER: cosmosDbContainerName
       AZURE_COSMOSDB_DATABASE: cosmosDbDatabaseName
@@ -235,9 +233,8 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
     }
     useOpenAiGpt4: useOpenAiGpt4
     openAiGpt35TurboDeploymentName: openAiGpt35TurboDeploymentName
-    openAiGpt35Turbo16kDeploymentName: openAiGpt35Turbo16kDeploymentName
     openAiGpt4DeploymentName: openAiGpt4DeploymentName
-    openAiGpt432kDeploymentName: openAiGpt432kDeploymentName
+    openAiGpt4oDeploymentName: openAiGpt4oDeploymentName
     publicNetworkAccess: isPrivateNetworkEnabled ? 'Disabled' : 'Enabled'
   }
 }
@@ -704,9 +701,8 @@ output AZURE_RESOURCE_GROUP string = resourceGroup.name
 output AZURE_OPENAI_SERVICE string = openAi.outputs.name
 output AZURE_OPENAI_RESOURCE_GROUP string = openAiResourceGroup.name
 output AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT string = openAiGpt35TurboDeploymentName
-output AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT string = openAiGpt35Turbo16kDeploymentName
 output AZURE_OPENAI_GPT_4_DEPLOYMENT string = openAiGpt4DeploymentName
-output AZURE_OPENAI_GPT_4_32K_DEPLOYMENT string = openAiGpt432kDeploymentName
+output AZURE_OPENAI_GPT_4O_DEPLOYMENT string = openAiGpt4oDeploymentName
 output AZURE_OPENAI_API_VERSION string = openAiApiVersion
 output AZURE_OPENAI_RESOURCE_GROUP_LOCATION string = openAiResourceGroupLocation
 output USE_OPENAI_GPT4 bool = useOpenAiGpt4

--- a/5.internal-document-search/src/backend/core/modelhelper.py
+++ b/5.internal-document-search/src/backend/core/modelhelper.py
@@ -5,9 +5,8 @@ import json
 import tiktoken
 
 AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT")
-AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT")
 AZURE_OPENAI_GPT_4_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_4_DEPLOYMENT")
-AZURE_OPENAI_GPT_4_32K_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_4_32K_DEPLOYMENT")
+AZURE_OPENAI_GPT_4O_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_4O_DEPLOYMENT")
 
 gpt_models = {
     "gpt-3.5-turbo": {
@@ -15,20 +14,15 @@ gpt_models = {
         "max_tokens": 4096,
         "encoding": tiktoken.encoding_for_model("gpt-3.5-turbo")
     },
-    "gpt-3.5-turbo-16k": {
-        "deployment": AZURE_OPENAI_GPT_35_TURBO_16K_DEPLOYMENT,
-        "max_tokens": 16384,
-        "encoding": tiktoken.encoding_for_model("gpt-3.5-turbo")
-    },
     "gpt-4": {
         "deployment": AZURE_OPENAI_GPT_4_DEPLOYMENT,
-        "max_tokens": 8192,
+        "max_tokens": 4096,
         "encoding": tiktoken.encoding_for_model("gpt-4")
     },
-    "gpt-4-32k": {
-        "deployment": AZURE_OPENAI_GPT_4_32K_DEPLOYMENT,
-        "max_tokens": 32768,
-        "encoding": tiktoken.encoding_for_model("gpt-4-32k")
+    "gpt-4o": {
+        "deployment": AZURE_OPENAI_GPT_4O_DEPLOYMENT,
+        "max_tokens": 16384,
+        "encoding": tiktoken.encoding_for_model("gpt-4o")
     }
 }
 

--- a/5.internal-document-search/src/backend/requirements.txt
+++ b/5.internal-document-search/src/backend/requirements.txt
@@ -1,10 +1,10 @@
 azure-identity==1.15.0
 Flask==3.0.2
-openai==1.12.0
+openai==1.63.2
 azure-search-documents==11.4.0
 azure-storage-blob==12.19.0
 azure-cosmos==4.5.1
 azure-monitor-opentelemetry==1.2.0
 opencensus-ext-azure==1.1.13
-tiktoken==0.6.0
+tiktoken==0.9.0
 opentelemetry-instrumentation-flask==0.48b0

--- a/5.internal-document-search/src/frontend/src/pages/chat/Chat.tsx
+++ b/5.internal-document-search/src/frontend/src/pages/chat/Chat.tsx
@@ -29,9 +29,8 @@ const Chat = () => {
 
     const gpt_models: IDropdownOption[] = [
         { key: "gpt-3.5-turbo", text: "gpt-3.5-turbo" },
-        { key: "gpt-3.5-turbo-16k", text: "gpt-3.5-turbo-16k" },
         { key: "gpt-4", text: "gpt-4" },
-        { key: "gpt-4-32k", text: "gpt-4-32k" }
+        { key: "gpt-4o", text: "gpt-4o" }
     ];
 
     const temperatures: IDropdownOption[] = Array.from({ length: 11 }, (_, i) => ({ key: (i / 10).toFixed(1), text: (i / 10).toFixed(1) }));

--- a/5.internal-document-search/src/frontend/src/pages/docsearch/DocSearch.tsx
+++ b/5.internal-document-search/src/frontend/src/pages/docsearch/DocSearch.tsx
@@ -39,9 +39,8 @@ const DocSearch = () => {
 
     const gpt_models: IDropdownOption[] = [
         { key: "gpt-3.5-turbo", text: "gpt-3.5-turbo" },
-        { key: "gpt-3.5-turbo-16k", text: "gpt-3.5-turbo-16k" },
         { key: "gpt-4", text: "gpt-4" },
-        { key: "gpt-4-32k", text: "gpt-4-32k" }
+        { key: "gpt-4o", text: "gpt-4o" }
     ];
 
     const temperatures: IDropdownOption[] = Array.from({ length: 11 }, (_, i) => ({ key: (i / 10).toFixed(1), text: (i / 10).toFixed(1) }));


### PR DESCRIPTION
# 変更点
- アプリで利用可能な GPT モデルを更新
  - gpt-3.5-turbo 0613 を gpt-3.5-turbo turbo-2024-04-09 (最新 GA モデル) にバージョンアップ
  - gpt-35-turbo-16k と gpt-4-32k を廃止
  - gpt-4o 2024-11-20 を利用可能に

# 変更理由
- 一部 GPT モデルの廃止 (gpt-3.5-turbo の 0613 は 2025/2/13 に廃止)
<img width="681" alt="リファレンスアーキテクチャエラー" src="https://github.com/user-attachments/assets/01bbaf8c-f633-4527-87b1-14f658eff101" />

# スクリーンショット
- gpt-3.5-turbo, gpt-4, gpt-4o の各モデルにおいて、チャットと RAG が可能なことを確認

![image](https://github.com/user-attachments/assets/7916e74d-5755-4b53-83fc-9658cdc1d6df)
![image](https://github.com/user-attachments/assets/16ac2fc1-6cd9-408e-a398-779571f2d9da)
![image](https://github.com/user-attachments/assets/2a15f331-f57d-4ed6-bbb8-7bdcc29d82e6)
![image](https://github.com/user-attachments/assets/b17ff80c-c4c5-4b2a-bb9e-4c2d52b7b9be)
![image](https://github.com/user-attachments/assets/5f29d54d-bff0-4cb7-864d-1518637e00d3)
![image](https://github.com/user-attachments/assets/c21c56ee-f3c9-4fd6-9dc0-1e10698763bd)