### PR TITLE
GPT モデルの Global Standard デプロイ対応

### DIFF
--- a/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
+++ b/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
@@ -10,10 +10,15 @@ param sku object = {
   name: 'S0'
 }
 
-param useOpenAiGpt4 bool = true
+param useGlobalStandard bool = true
+param useAoaiGpt35Turbo bool = true
+param useAoaiGpt4 bool = true
+param useAoaiGpt4o bool = true
 param openAiGpt35TurboDeploymentName string = ''
 param openAiGpt4DeploymentName string = ''
+param openAiGpt4GlobalDeploymentName string = ''
 param openAiGpt4oDeploymentName string = ''
+param openAiGpt4oGlobalDeploymentName string = ''
 
 param openAiGpt35TurboDeployObj object = {
   name: openAiGpt35TurboDeploymentName
@@ -41,6 +46,19 @@ param openAiGpt4DeployObj object = {
   }
 }
 
+param openAiGpt4GlobalDeployObj object = {
+  name: openAiGpt4GlobalDeploymentName
+  model: {
+    format: 'OpenAI'
+    name: 'gpt-4'
+    version: 'turbo-2024-04-09'
+  }
+  sku: {
+    name: 'GlobalStandard'
+    capacity: 40
+  }
+}
+
 param openAiGpt4oDeployObj object = {
   name: openAiGpt4oDeploymentName
   model: {
@@ -54,13 +72,27 @@ param openAiGpt4oDeployObj object = {
   }
 }
 
-param deployments array = useOpenAiGpt4? [
-  openAiGpt35TurboDeployObj
-  openAiGpt4DeployObj
-  openAiGpt4oDeployObj
-]: [
-  openAiGpt35TurboDeployObj
-]
+param openAiGpt4oGlobalDeployObj object = {
+  name: openAiGpt4oGlobalDeploymentName
+  model: {
+    format: 'OpenAI'
+    name: 'gpt-4o'
+    version: '2024-11-20'
+  }
+  sku: {
+    name: 'GlobalStandard'
+    capacity: 40
+  }
+}
+
+param deployments array = useGlobalStandard ? concat(
+  useAoaiGpt4 && !empty(openAiGpt4GlobalDeployObj.name) ? [ openAiGpt4GlobalDeployObj ] : [],
+  useAoaiGpt4o && !empty(openAiGpt4oGlobalDeployObj.name) ? [ openAiGpt4oGlobalDeployObj ] : []
+) : concat(
+  useAoaiGpt35Turbo && !empty(openAiGpt35TurboDeployObj.name) ? [ openAiGpt35TurboDeployObj ] : [],
+  useAoaiGpt4 && !empty(openAiGpt4DeployObj.name) ? [ openAiGpt4DeployObj ] : [],
+  useAoaiGpt4o && !empty(openAiGpt4oDeployObj.name) ? [ openAiGpt4oDeployObj ] : []
+)
 
 resource account 'Microsoft.CognitiveServices/accounts@2023-05-01' = {
   name: name

--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -37,28 +37,42 @@ param openAiServiceName string = ''
 param openAiResourceGroupName string = ''
 
 @allowed([
-  '1.  australiaeast    (You can deploy GPT-4 and GPT-3 models)'
-  '2.  canadaeast       (You can deploy GPT-4 and GPT-3 models)'
-  '3.  swedencentral    (You can deploy GPT-4 and GPT-3 models)'
-  '4.  switzerlandnorth (You can deploy GPT-4 and GPT-3 models)'
-  '5.  eastus           (You can deploy only GPT-3 models)'
-  '6.  eastus2          (You can deploy only GPT-3 models)'
-  '7.  francecentral    (You can deploy only GPT-3 models)'
-  '8.  japaneast        (You can deploy only GPT-3 models)'
-  '9.  northcentralus   (You can deploy only GPT-3 models)'
-  '10. uksouth          (You can deploy only GPT-3 models)'
+  '1. |  japaneast      |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09):    |  gpt-35-turbo (0125): ✓  |'
+  '2. |  japaneast      |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
+  '3. |  australiaeast  |  Standard         |  gpt-4o (2024-1120):    |  gpt-4 (turbo-2024-04-09):    |  gpt-35-turbo (0125): ✓  |'
+  '4. |  australiaeast  |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
+  '5. |  swedencentral  |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125): ✓  |'
+  '6. |  swedencentral  |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
+  '7. |  eastus         |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125): ✓  |'
+  '8. |  eastus         |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
+  '9. |  eastus2        |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125): ✓  |'
+  '10.|  eastus2        |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
 ])
 param AzureOpenAIServiceRegion string
 
-param delimiters array = ['.', '(']
-param aoaiRegionWithBlankSpace string = split(AzureOpenAIServiceRegion, delimiters)[1]
-param openAiResourceGroupLocation string = trim(aoaiRegionWithBlankSpace)
-param useOpenAiGpt4 bool = contains(AzureOpenAIServiceRegion, 'GPT-4')
+param delimiters array = ['|']
+
+param aoaiResourceGroupLocationWithBlankSpace string = split(AzureOpenAIServiceRegion, delimiters)[1]
+param aoaiResourceGroupLocation string = trim(aoaiResourceGroupLocationWithBlankSpace)
+
+param aoaiDeployOptionWithBlankSpace string = split(AzureOpenAIServiceRegion, delimiters)[2]
+param useGlobalStandard bool = contains(aoaiDeployOptionWithBlankSpace, 'Global')
+
+param aoaiGpt35TurboDeployWithBlankSpace string = split(AzureOpenAIServiceRegion, delimiters)[5]
+param useAoaiGpt35Turbo bool = contains(aoaiGpt35TurboDeployWithBlankSpace, '✓')
+
+param aoaiGpt4DeployWithBlankSpace string = split(AzureOpenAIServiceRegion, delimiters)[4]
+param useAoaiGpt4 bool = contains(aoaiGpt4DeployWithBlankSpace, '✓')
+
+param aoaiGpt4oDeployWithBlankSpace string = split(AzureOpenAIServiceRegion, delimiters)[3]
+param useAoaiGpt4o bool = contains(aoaiGpt4oDeployWithBlankSpace, '✓')
 
 param openAiSkuName string = 'S0'
 param openAiGpt35TurboDeploymentName string = 'gpt-35-turbo-deploy'
 param openAiGpt4DeploymentName string = 'gpt-4-deploy'
+param openAiGpt4GlobalDeploymentName string = 'gpt-4-global-deploy'
 param openAiGpt4oDeploymentName string = 'gpt-4o-deploy'
+param openAiGpt4oGlobalDeploymentName string = 'gpt-4o-global-deploy'
 param openAiApiVersion string = '2023-05-15'
 
 param formRecognizerServiceName string = ''
@@ -209,7 +223,9 @@ module backend 'core/host/appservice.bicep' = {
       AZURE_SEARCH_SERVICE: searchService.outputs.name
       AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT: openAiGpt35TurboDeploymentName
       AZURE_OPENAI_GPT_4_DEPLOYMENT: openAiGpt4DeploymentName
+      AZURE_OPENAI_GPT_4_GLOBAL_DEPLOYMENT: openAiGpt4GlobalDeploymentName
       AZURE_OPENAI_GPT_4O_DEPLOYMENT: openAiGpt4oDeploymentName
+      AZURE_OPENAI_GPT_4O_GLOBAL_DEPLOYMENT: openAiGpt4oGlobalDeploymentName
       AZURE_OPENAI_API_VERSION: '2023-05-15'
       AZURE_COSMOSDB_CONTAINER: cosmosDbContainerName
       AZURE_COSMOSDB_DATABASE: cosmosDbDatabaseName
@@ -217,6 +233,10 @@ module backend 'core/host/appservice.bicep' = {
       API_MANAGEMENT_ENDPOINT: useApiManagement ? apimApi.outputs.apiManagementEndpoint : ''
       ENTRA_CLIENT_ID: audienceClientAppId
       USE_API_MANAGEMENT: useApiManagement
+      USE_GLOBAL_STANDARD: useGlobalStandard
+      USE_AOAI_GPT_35_TURBO: useAoaiGpt35Turbo
+      USE_AOAI_GPT_4: useAoaiGpt4
+      USE_AOAI_GPT_4O: useAoaiGpt4o
     }
   }
 }
@@ -226,15 +246,20 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
   scope: openAiResourceGroup
   params: {
     name: !empty(openAiServiceName) ? openAiServiceName : '${abbrs.cognitiveServicesAccounts}${resourceToken}'
-    location: openAiResourceGroupLocation
+    location: aoaiResourceGroupLocation
     tags: tags
     sku: {
       name: openAiSkuName
     }
-    useOpenAiGpt4: useOpenAiGpt4
+    useGlobalStandard: useGlobalStandard
+    useAoaiGpt35Turbo: useAoaiGpt35Turbo
+    useAoaiGpt4: useAoaiGpt4
+    useAoaiGpt4o: useAoaiGpt4o 
     openAiGpt35TurboDeploymentName: openAiGpt35TurboDeploymentName
     openAiGpt4DeploymentName: openAiGpt4DeploymentName
+    openAiGpt4GlobalDeploymentName: openAiGpt4GlobalDeploymentName
     openAiGpt4oDeploymentName: openAiGpt4oDeploymentName
+    openAiGpt4oGlobalDeploymentName: openAiGpt4oGlobalDeploymentName
     publicNetworkAccess: isPrivateNetworkEnabled ? 'Disabled' : 'Enabled'
   }
 }
@@ -250,7 +275,6 @@ module formRecognizer 'core/ai/cognitiveservices.bicep' = {
     sku: {
       name: formRecognizerSkuName
     }
-    deployments: []
   }
 }
 
@@ -702,10 +726,15 @@ output AZURE_OPENAI_SERVICE string = openAi.outputs.name
 output AZURE_OPENAI_RESOURCE_GROUP string = openAiResourceGroup.name
 output AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT string = openAiGpt35TurboDeploymentName
 output AZURE_OPENAI_GPT_4_DEPLOYMENT string = openAiGpt4DeploymentName
+output AZURE_OPENAI_GPT_4_GLOBAL_DEPLOYMENT string = openAiGpt4GlobalDeploymentName
 output AZURE_OPENAI_GPT_4O_DEPLOYMENT string = openAiGpt4oDeploymentName
+output AZURE_OPENAI_GPT_4O_GLOBAL_DEPLOYMENT string = openAiGpt4oGlobalDeploymentName
 output AZURE_OPENAI_API_VERSION string = openAiApiVersion
-output AZURE_OPENAI_RESOURCE_GROUP_LOCATION string = openAiResourceGroupLocation
-output USE_OPENAI_GPT4 bool = useOpenAiGpt4
+output AZURE_OPENAI_RESOURCE_GROUP_LOCATION string = aoaiResourceGroupLocation
+output USE_GLOBAL_STANDARD bool = useGlobalStandard
+output USE_AOAI_GPT35_TURBO bool = useAoaiGpt35Turbo
+output USE_AOAI_GPT_4 bool = useAoaiGpt4
+output USE_AOAI_GPT_4O bool = useAoaiGpt4o
 
 output AZURE_FORMRECOGNIZER_SERVICE string = formRecognizer.outputs.name
 output AZURE_FORMRECOGNIZER_RESOURCE_GROUP string = formRecognizerResourceGroup.name

--- a/5.internal-document-search/src/backend/app.py
+++ b/5.internal-document-search/src/backend/app.py
@@ -10,7 +10,7 @@ from azure.storage.blob import BlobServiceClient
 from approaches.chatlogging import get_user_name, write_error
 from approaches.chatreadretrieveread import ChatReadRetrieveReadApproach
 from approaches.chatread import ChatReadApproach
-from core.openaiclienthelper import get_openai_clients
+from core.openaiclienthelper import get_available_aoai_models, get_openai_clients
 
 from azure.monitor.opentelemetry import configure_azure_monitor
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
@@ -36,6 +36,7 @@ AZURE_OPENAI_SERVICE = os.environ.get("AZURE_OPENAI_SERVICE")
 azure_credential = DefaultAzureCredential()
 openai_token = azure_credential.get_token("https://cognitiveservices.azure.com/.default")
 
+available_aoai_models = get_available_aoai_models()
 openai_clients = get_openai_clients(openai_token.token, azure_credential)
 
 # Set up clients for Cognitive Search and Storage
@@ -66,6 +67,10 @@ FlaskInstrumentor().instrument_app(app)
 @app.route("/<path:path>")
 def static_file(path):
     return app.send_static_file(path)
+
+@app.route("/available_models")
+def available_models():
+    return jsonify(available_aoai_models)
 
 # Serve content files from blob storage from within the app to keep the example self-contained. 
 # *** NOTE *** this assumes that the content files are public, or at least that all users of the app

--- a/5.internal-document-search/src/backend/core/modelhelper.py
+++ b/5.internal-document-search/src/backend/core/modelhelper.py
@@ -4,9 +4,23 @@ import os
 import json
 import tiktoken
 
+USE_GLOBAL_STANDARD = os.environ.get("USE_GLOBAL_STANDARD", "").lower() == "true"
+USE_AOAI_GPT_35_TURBO = os.environ.get("USE_AOAI_GPT_35_TURBO", "").lower() == "true"
+USE_AOAI_GPT_4 = os.environ.get("USE_AOAI_GPT_4", "").lower() == "true"
+USE_AOAI_GPT_4O = os.environ.get("USE_AOAI_GPT_4O", "").lower() == "true"
 AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_35_TURBO_DEPLOYMENT")
 AZURE_OPENAI_GPT_4_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_4_DEPLOYMENT")
+AZURE_OPENAI_GPT_4_GLOBAL_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_4_GLOBAL_DEPLOYMENT")
 AZURE_OPENAI_GPT_4O_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_4O_DEPLOYMENT")
+AZURE_OPENAI_GPT_4O_GLOBAL_DEPLOYMENT = os.environ.get("AZURE_OPENAI_GPT_4O_GLOBAL_DEPLOYMENT")
+
+use_aoai_models = {
+    "gpt-3.5-turbo": USE_AOAI_GPT_35_TURBO and not USE_GLOBAL_STANDARD,
+    "gpt-4": USE_AOAI_GPT_4 and not USE_GLOBAL_STANDARD,
+    "gpt-4-global": USE_AOAI_GPT_4 and USE_GLOBAL_STANDARD,
+    "gpt-4o": USE_AOAI_GPT_4O and not USE_GLOBAL_STANDARD,
+    "gpt-4o-global": USE_AOAI_GPT_4O and USE_GLOBAL_STANDARD
+}
 
 gpt_models = {
     "gpt-3.5-turbo": {
@@ -19,8 +33,18 @@ gpt_models = {
         "max_tokens": 4096,
         "encoding": tiktoken.encoding_for_model("gpt-4")
     },
+    "gpt-4-global": {
+        "deployment": AZURE_OPENAI_GPT_4_GLOBAL_DEPLOYMENT,
+        "max_tokens": 4096,
+        "encoding": tiktoken.encoding_for_model("gpt-4")
+    },
     "gpt-4o": {
         "deployment": AZURE_OPENAI_GPT_4O_DEPLOYMENT,
+        "max_tokens": 16384,
+        "encoding": tiktoken.encoding_for_model("gpt-4o")
+    },
+    "gpt-4o-global": {
+        "deployment": AZURE_OPENAI_GPT_4O_GLOBAL_DEPLOYMENT,
         "max_tokens": 16384,
         "encoding": tiktoken.encoding_for_model("gpt-4o")
     }
@@ -75,6 +99,9 @@ gpt_models = {
 #     if aoaimodel not in AOAI_2_OAI and aoaimodel not in MODELS_2_TOKEN_LIMITS:
 #         raise ValueError(message)
 #     return AOAI_2_OAI.get(aoaimodel) or aoaimodel
+
+def get_use_aoai_models() -> dict:
+    return use_aoai_models
 
 def get_gpt_model(model_name: str) -> dict:
     return gpt_models.get(model_name)

--- a/5.internal-document-search/src/backend/core/openaiclienthelper.py
+++ b/5.internal-document-search/src/backend/core/openaiclienthelper.py
@@ -1,13 +1,16 @@
 import os
 from azure.identity import DefaultAzureCredential
 from openai import AzureOpenAI
-from core.modelhelper import get_gpt_model, get_gpt_models
+from core.modelhelper import get_use_aoai_models, get_gpt_model, get_gpt_models
 
 AZURE_OPENAI_SERVICE = os.environ.get("AZURE_OPENAI_SERVICE")
 AZURE_OPENAI_API_VERSION = os.environ.get("AZURE_OPENAI_API_VERSION")
 API_MANAGEMENT_ENDPOINT = os.environ.get("API_MANAGEMENT_ENDPOINT")
 ENTRA_CLIENT_ID = os.environ.get("ENTRA_CLIENT_ID")
 USE_API_MANAGEMENT = True if os.environ.get("USE_API_MANAGEMENT").lower() == "true" else False
+
+def get_available_aoai_models() -> dict:
+    return get_use_aoai_models()
 
 def get_openai_clients(api_key: str, azure_credential: DefaultAzureCredential) -> dict:
     openai_clients = {}

--- a/5.internal-document-search/src/frontend/src/pages/chat/Chat.tsx
+++ b/5.internal-document-search/src/frontend/src/pages/chat/Chat.tsx
@@ -35,7 +35,6 @@ const Chat = () => {
                 const parsedData = Object.fromEntries(
                     Object.entries(data).map(([key, value]) => [key, value === true])
                 );
-                console.log("Fetched models:", parsedData);
                 setAvailableModels(parsedData);
             })
             .catch((err) => {

--- a/5.internal-document-search/src/frontend/src/pages/chat/Chat.tsx
+++ b/5.internal-document-search/src/frontend/src/pages/chat/Chat.tsx
@@ -17,6 +17,7 @@ const Chat = () => {
     const [gptModel, setGptModel] = useState<string>("gpt-3.5-turbo");
     const [systemPrompt, setSystemPrompt] = useState<string>("");
     const [temperature, setTemperature] = useState<string>("0.0");
+    const [availableModels, setAvailableModels] = useState<Record<string, any>>({});
 
     const lastQuestionRef = useRef<string>("");
     const chatMessageStreamEnd = useRef<HTMLDivElement | null>(null);
@@ -27,11 +28,33 @@ const Chat = () => {
     const [selectedAnswer, setSelectedAnswer] = useState<number>(0);
     const [answers, setAnswers] = useState<[user: string, response: ChatResponse][]>([]);
 
+    useEffect(() => {
+        fetch("/available_models")
+            .then((response) => response.json())
+            .then((data) => {
+                const parsedData = Object.fromEntries(
+                    Object.entries(data).map(([key, value]) => [key, value === true])
+                );
+                console.log("Fetched models:", parsedData);
+                setAvailableModels(parsedData);
+            })
+            .catch((err) => {
+                console.error("Error fetching models:", err);
+            });
+    }, []);
+    
     const gpt_models: IDropdownOption[] = [
         { key: "gpt-3.5-turbo", text: "gpt-3.5-turbo" },
         { key: "gpt-4", text: "gpt-4" },
-        { key: "gpt-4o", text: "gpt-4o" }
+        { key: "gpt-4-global", text: "gpt-4-global" },
+        { key: "gpt-4o", text: "gpt-4o" },
+        { key: "gpt-4o-global", text: "gpt-4o-global" }
     ];
+
+    const filteredGptModels: IDropdownOption[] =
+    (availableModels && Object.keys(availableModels).length > 0)
+        ? gpt_models.filter(option => availableModels[option.key])
+        : gpt_models;
 
     const temperatures: IDropdownOption[] = Array.from({ length: 11 }, (_, i) => ({ key: (i / 10).toFixed(1), text: (i / 10).toFixed(1) }));
 
@@ -144,7 +167,7 @@ const Chat = () => {
                         defaultSelectedKeys={[gptModel]}
                         selectedKey={gptModel}
                         label="GPT Model:"
-                        options={gpt_models}
+                        options={filteredGptModels}
                         onChange={onGptModelChange}
                     />
                     <TextField


### PR DESCRIPTION
# 変更点
- アプリで利用可能な GPT モデルを更新
  - gpt-4 と gpt-4o のグローバルスタンダードデプロイを選択できるように
  - デプロイ済みのモデルのみ UI から選択できるように

# 変更理由
- 新規 GPT モデルの利用対応のため

# スクリーンショット
- Japan East の Standard デプロイ
![image](https://github.com/user-attachments/assets/763f70c0-fe41-4940-a346-9e1af767dad6)
![image](https://github.com/user-attachments/assets/c8bc4a60-8323-4fe3-b2c9-42204f193aa3)
![image](https://github.com/user-attachments/assets/638913bf-2fae-462f-b34a-bcbf26e5e2c3)
- Japan East の Global Standard デプロイ
![image](https://github.com/user-attachments/assets/4253dad4-9709-4a98-bcb5-c80b4701b2ca)
![image](https://github.com/user-attachments/assets/de2be87c-b924-4138-8c31-ff2bcdc98557)
![image](https://github.com/user-attachments/assets/ab8fa294-1975-4a7d-bd0b-39c669264ef2)