### PR TITLE
Dependabot が PR 作成するディレクトリを指定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/5.internal-document-search/"
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: "npm"
+    directory: "/5.internal-document-search/"
+    schedule:
+      interval: weekly


### PR DESCRIPTION
# 変更点
- Dependabot が PR 作成するディレクトリを指定 (5 章のみ指定)

# 変更理由
- 5 章以外の PR 作成を防止するため

# 参考ドキュメント
https://docs.github.com/ja/code-security/dependabot/working-with-dependabot/dependabot-options-reference#about-the-dependabotyml-file