### PR TITLE
[2025/12月分] dependabot による PR の統合テスト 

### DIFF
--- a/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
+++ b/5.internal-document-search/infra/core/ai/cognitiveservices.bicep
@@ -33,32 +33,6 @@ param openAiGpt35TurboDeployObj object = {
   }
 }
 
-param openAiGpt4DeployObj object = {
-  name: openAiGpt4DeploymentName
-  model: {
-    format: 'OpenAI'
-    name: 'gpt-4'
-    version: 'turbo-2024-04-09'
-  }
-  sku: {
-    name: 'Standard'
-    capacity: 40
-  }
-}
-
-param openAiGpt4GlobalDeployObj object = {
-  name: openAiGpt4GlobalDeploymentName
-  model: {
-    format: 'OpenAI'
-    name: 'gpt-4'
-    version: 'turbo-2024-04-09'
-  }
-  sku: {
-    name: 'GlobalStandard'
-    capacity: 40
-  }
-}
-
 param openAiGpt4oDeployObj object = {
   name: openAiGpt4oDeploymentName
   model: {
@@ -86,11 +60,9 @@ param openAiGpt4oGlobalDeployObj object = {
 }
 
 param deployments array = useGlobalStandard ? concat(
-  useAoaiGpt4 && !empty(openAiGpt4GlobalDeployObj.name) ? [ openAiGpt4GlobalDeployObj ] : [],
   useAoaiGpt4o && !empty(openAiGpt4oGlobalDeployObj.name) ? [ openAiGpt4oGlobalDeployObj ] : []
 ) : concat(
   useAoaiGpt35Turbo && !empty(openAiGpt35TurboDeployObj.name) ? [ openAiGpt35TurboDeployObj ] : [],
-  useAoaiGpt4 && !empty(openAiGpt4DeployObj.name) ? [ openAiGpt4DeployObj ] : [],
   useAoaiGpt4o && !empty(openAiGpt4oDeployObj.name) ? [ openAiGpt4oDeployObj ] : []
 )
 

--- a/5.internal-document-search/infra/core/network/nic.bicep
+++ b/5.internal-document-search/infra/core/network/nic.bicep
@@ -29,4 +29,4 @@ resource networkInterface 'Microsoft.Network/networkInterfaces@2023-11-01' = if 
   }
 }
 
-output nicId string = networkInterface.?id
+output nicId string = networkInterface.id ?? ''

--- a/5.internal-document-search/infra/core/vm/vm.bicep
+++ b/5.internal-document-search/infra/core/vm/vm.bicep
@@ -4,7 +4,7 @@ param adminUsername string
 @secure()
 param adminPasswordOrKey string
 param vmSize string = 'Standard_D2s_v3'
-param nicId string
+param nicId string = ''
 param osDiskType string = 'Standard_LRS'
 param isPrivateNetworkEnabled bool
 

--- a/5.internal-document-search/infra/main.bicep
+++ b/5.internal-document-search/infra/main.bicep
@@ -37,16 +37,16 @@ param openAiServiceName string = ''
 param openAiResourceGroupName string = ''
 
 @allowed([
-  '1. |  japaneast      |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09):    |  gpt-35-turbo (0125): ✓  |'
-  '2. |  japaneast      |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
-  '3. |  australiaeast  |  Standard         |  gpt-4o (2024-1120):    |  gpt-4 (turbo-2024-04-09):    |  gpt-35-turbo (0125): ✓  |'
-  '4. |  australiaeast  |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
-  '5. |  swedencentral  |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125): ✓  |'
-  '6. |  swedencentral  |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
-  '7. |  eastus         |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125): ✓  |'
-  '8. |  eastus         |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
-  '9. |  eastus2        |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125): ✓  |'
-  '10.|  eastus2        |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-4 (turbo-2024-04-09): ✓  |  gpt-35-turbo (0125):    |'
+  '1. |  japaneast      |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125): ✓  |'
+  '2. |  japaneast      |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125):    |'
+  '3. |  australiaeast  |  Standard         |  gpt-4o (2024-1120):    |  gpt-35-turbo (0125): ✓  |'
+  '4. |  australiaeast  |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125):    |'
+  '5. |  swedencentral  |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125): ✓  |'
+  '6. |  swedencentral  |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125):    |'
+  '7. |  eastus         |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125): ✓  |'
+  '8. |  eastus         |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125):    |'
+  '9. |  eastus2        |  Standard         |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125): ✓  |'
+  '10.|  eastus2        |  Global Standard  |  gpt-4o (2024-1120): ✓  |  gpt-35-turbo (0125):    |'
 ])
 param AzureOpenAIServiceRegion string
 

--- a/5.internal-document-search/scripts/requirements.txt
+++ b/5.internal-document-search/scripts/requirements.txt
@@ -1,6 +1,6 @@
 azure-identity==1.25.0
 azure-search-documents==11.5.3
 azure-ai-formrecognizer==3.3.3
-pypdf==6.0.0
+pypdf==6.4.0
 azure-storage-blob==12.26.0
 typing==3.7.4.3

--- a/5.internal-document-search/scripts/requirements.txt
+++ b/5.internal-document-search/scripts/requirements.txt
@@ -2,5 +2,5 @@ azure-identity==1.25.0
 azure-search-documents==11.5.3
 azure-ai-formrecognizer==3.3.3
 pypdf==6.0.0
-azure-storage-blob==12.26.0
+azure-storage-blob==12.27.1
 typing==3.7.4.3

--- a/5.internal-document-search/scripts/requirements.txt
+++ b/5.internal-document-search/scripts/requirements.txt
@@ -1,4 +1,4 @@
-azure-identity==1.25.0
+azure-identity==1.25.1
 azure-search-documents==11.5.3
 azure-ai-formrecognizer==3.3.3
 pypdf==6.0.0

--- a/5.internal-document-search/scripts/requirements.txt
+++ b/5.internal-document-search/scripts/requirements.txt
@@ -1,5 +1,5 @@
 azure-identity==1.25.0
-azure-search-documents==11.5.3
+azure-search-documents==11.6.0
 azure-ai-formrecognizer==3.3.3
 pypdf==6.0.0
 azure-storage-blob==12.26.0

--- a/5.internal-document-search/src/frontend/src/pages/docsearch/DocSearch.tsx
+++ b/5.internal-document-search/src/frontend/src/pages/docsearch/DocSearch.tsx
@@ -19,6 +19,7 @@ const DocSearch = () => {
 
     const [gptModel, setGptModel] = useState<string>("gpt-3.5-turbo");
     const [temperature, setTemperature] = useState<string>("0.0");
+    const [availableModels, setAvailableModels] = useState<Record<string, any>>({});
 
     const [retrieveCount, setRetrieveCount] = useState<number>(5);
     const [useSemanticRanker, setUseSemanticRanker] = useState<boolean>(true);
@@ -37,11 +38,32 @@ const DocSearch = () => {
     const [selectedAnswer, setSelectedAnswer] = useState<number>(0);
     const [answers, setAnswers] = useState<[user: string, response: AskResponse][]>([]);
 
+    useEffect(() => {
+        fetch("/available_models")
+            .then((response) => response.json())
+            .then((data) => {
+                const parsedData = Object.fromEntries(
+                    Object.entries(data).map(([key, value]) => [key, value === true])
+                );
+                setAvailableModels(parsedData);
+            })
+            .catch((err) => {
+                console.error("Error fetching models:", err);
+            });
+    }, []);
+
     const gpt_models: IDropdownOption[] = [
         { key: "gpt-3.5-turbo", text: "gpt-3.5-turbo" },
         { key: "gpt-4", text: "gpt-4" },
-        { key: "gpt-4o", text: "gpt-4o" }
+        { key: "gpt-4-global", text: "gpt-4-global" },
+        { key: "gpt-4o", text: "gpt-4o" },
+        { key: "gpt-4o-global", text: "gpt-4o-global" }
     ];
+
+    const filteredGptModels: IDropdownOption[] =
+    (availableModels && Object.keys(availableModels).length > 0)
+        ? gpt_models.filter(option => availableModels[option.key])
+        : gpt_models;
 
     const temperatures: IDropdownOption[] = Array.from({ length: 11 }, (_, i) => ({ key: (i / 10).toFixed(1), text: (i / 10).toFixed(1) }));
 
@@ -228,7 +250,7 @@ const DocSearch = () => {
                         defaultSelectedKeys={[gptModel]}
                         selectedKey={gptModel}
                         label="GPT Model:"
-                        options={gpt_models}
+                        options={filteredGptModels}
                         onChange={onGptModelChange}
                     />
                     <Dropdown


### PR DESCRIPTION
# 概要
dependabot により作成された以下 5 件分の PR の統合テスト
- https://github.com/Azure-Samples/jp-azureopenai-samples/pull/210
- https://github.com/Azure-Samples/jp-azureopenai-samples/pull/209
- https://github.com/Azure-Samples/jp-azureopenai-samples/pull/207
- https://github.com/Azure-Samples/jp-azureopenai-samples/pull/201
- https://github.com/Azure-Samples/jp-azureopenai-samples/pull/200

# 更新ライブラリ一覧
- azure-identity (1.25.0 to 1.25.1)
- pypdf (6.0.0 to 6.4.0)
- azure-storage-blob (12.26.0 to 12.27.1)
- azure-search-documents (11.5.3 to 11.6.0)

# エラー対応
- gpt-4 (turbo-2024-04-09) は廃止に伴うエラー
  - gpt-4 のデプロイを選択肢から削除
<img width="703" height="257" alt="スクリーンショット 2025-12-05 081813" src="https://github.com/user-attachments/assets/5abe71b5-0ca7-4966-b02e-76f59f4121cc" />

- パラーメーターの値が Null に伴うエラー
  - bicep で利用されている nicId パラメーターが Null となりエラーとなる (vnet 未使用の場合は nic がデプロイされない)
  - nicId が Null ではなく空文字となるように bicep を変更
<img width="702" height="85" alt="スクリーンショット 2025-12-05 083353" src="https://github.com/user-attachments/assets/105bcb98-88cd-4a27-8181-ed88ffa1232b" />

# UX 向上
- デプロイされていないモデルを非表示
  - 設定フィールドにおける GPT Model で、デプロイされていないモデルもプルダウンに表示されていたので、それに関する対応
<img width="957" height="499" alt="スクリーンショット 2025-12-05 130035" src="https://github.com/user-attachments/assets/ee0afe5d-5a9b-49a7-8db9-2de9a1c9ea8a" />

# スクリーンショット (テスト)
<img width="956" height="499" alt="スクリーンショット 2025-12-05 134055" src="https://github.com/user-attachments/assets/a1ee9585-c542-4b6b-a1f6-28bbac5969f8" />

<img width="956" height="494" alt="スクリーンショット 2025-12-05 134139" src="https://github.com/user-attachments/assets/2f17d3de-3bf9-4656-919f-824207f08ca4" />

※ 上記のスクリーンショットより、アクセストークンを取得して AOAI が利用でき (azure-identity の正常性確認)、PDF の表示ができ (pypdf と azure-storage-blob の正常確認)、社内文書検索ができた (azure-search-documents の正常確認) ことを確認。